### PR TITLE
Add AI utilities with orchestrator

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-draggable": "^4.4.6",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "openai": "^4.39.2",
+    "@pinecone-database/pinecone": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.12.0",

--- a/src/ai/agents.ts
+++ b/src/ai/agents.ts
@@ -1,0 +1,49 @@
+import { OpenAI } from 'openai';
+
+export class Agent {
+  constructor(private openai: OpenAI, private prompt: string) {}
+
+  async respond(message: string): Promise<string> {
+    const res = await this.openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: this.prompt },
+        { role: 'user', content: message },
+      ],
+    });
+    return res.choices[0]?.message?.content?.trim() ?? '';
+  }
+}
+
+export const NUTRITION_SYSTEM_PROMPT =
+  'You are a helpful nutrition assistant providing dietary advice.';
+export const GENERAL_SYSTEM_PROMPT =
+  'You are a fitness coach answering general workout questions.';
+export const SOCIAL_EVENT_SYSTEM_PROMPT =
+  'You help organize and suggest social workout events.';
+export const CLASSIFICATION_SYSTEM_PROMPT =
+  'Classify user messages as nutrition, general or social questions.';
+
+export class NutritionAgent extends Agent {
+  constructor(openai: OpenAI) {
+    super(openai, NUTRITION_SYSTEM_PROMPT);
+  }
+}
+
+export class GeneralAgent extends Agent {
+  constructor(openai: OpenAI) {
+    super(openai, GENERAL_SYSTEM_PROMPT);
+  }
+}
+
+export class SocialEventAgent extends Agent {
+  constructor(openai: OpenAI) {
+    super(openai, SOCIAL_EVENT_SYSTEM_PROMPT);
+  }
+}
+
+export class ClassificationAgent extends Agent {
+  constructor(openai: OpenAI) {
+    super(openai, CLASSIFICATION_SYSTEM_PROMPT);
+  }
+}

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -1,0 +1,4 @@
+export * from './vectorStores.ts';
+export * from './summarize.ts';
+export * from './agents.ts';
+export * from './orchestrator.ts';

--- a/src/ai/orchestrator.ts
+++ b/src/ai/orchestrator.ts
@@ -1,0 +1,50 @@
+import { OpenAI } from 'openai';
+import {
+  ClassificationAgent,
+  GeneralAgent,
+  NutritionAgent,
+  SocialEventAgent,
+} from './agents.ts';
+
+export class FitnessOrchestrator {
+  private openai: OpenAI;
+  private classifier: ClassificationAgent;
+  private nutrition: NutritionAgent;
+  private general: GeneralAgent;
+  private social: SocialEventAgent;
+
+  constructor(apiKey: string) {
+    this.openai = new OpenAI({ apiKey });
+    this.classifier = new ClassificationAgent(this.openai);
+    this.nutrition = new NutritionAgent(this.openai);
+    this.general = new GeneralAgent(this.openai);
+    this.social = new SocialEventAgent(this.openai);
+  }
+
+  async process(message: string): Promise<string> {
+    const category = await this.classify(message);
+    switch (category) {
+      case 'nutrition':
+        return this.nutrition.respond(message);
+      case 'social':
+        return this.social.respond(message);
+      default:
+        return this.general.respond(message);
+    }
+  }
+
+  private async classify(text: string): Promise<'nutrition' | 'general' | 'social'> {
+    const answer = await this.classifier.respond(
+      `${text}\nRespond with one word: nutrition, general, or social.`,
+    );
+    if (/nutrition/i.test(answer)) return 'nutrition';
+    if (/social/i.test(answer)) return 'social';
+    return 'general';
+  }
+}
+
+const orchestrator = new FitnessOrchestrator(process.env.OPENAI_API_KEY ?? '');
+
+export async function processUserMessage(message: string): Promise<string> {
+  return orchestrator.process(message);
+}

--- a/src/ai/summarize.ts
+++ b/src/ai/summarize.ts
@@ -1,0 +1,14 @@
+import { OpenAI } from 'openai';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY ?? '' });
+
+export async function summarizeText(text: string): Promise<string> {
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [
+      { role: 'system', content: 'Summarize the following text briefly.' },
+      { role: 'user', content: text },
+    ],
+  });
+  return completion.choices[0]?.message?.content?.trim() ?? '';
+}

--- a/src/ai/vectorStores.ts
+++ b/src/ai/vectorStores.ts
@@ -1,0 +1,59 @@
+export interface VectorItem {
+  id: string;
+  values: number[];
+  metadata?: Record<string, unknown>;
+}
+
+export class InMemoryVectorDB {
+  private store = new Map<string, VectorItem>();
+
+  upsert(item: VectorItem) {
+    this.store.set(item.id, item);
+  }
+
+  similaritySearch(vector: number[], topK = 5): VectorItem[] {
+    const scored = Array.from(this.store.values()).map((v) => ({
+      item: v,
+      score: cosineSimilarity(v.values, vector),
+    }));
+    return scored
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topK)
+      .map((s) => s.item);
+  }
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  const dot = a.reduce((sum, val, i) => sum + val * (b[i] ?? 0), 0);
+  const normA = Math.sqrt(a.reduce((sum, val) => sum + val * val, 0));
+  const normB = Math.sqrt(b.reduce((sum, val) => sum + val * val, 0));
+  return normA && normB ? dot / (normA * normB) : 0;
+}
+
+import { Pinecone } from '@pinecone-database/pinecone';
+
+export class LongTermVectorStore {
+  private index;
+
+  constructor(
+    apiKey: string,
+    environment: string,
+    indexName: string,
+  ) {
+    const client = new Pinecone({ apiKey, environment });
+    this.index = client.index(indexName);
+  }
+
+  async upsert(item: VectorItem) {
+    await this.index.upsert([{ ...item }]);
+  }
+
+  async query(vector: number[], topK = 5) {
+    const res = await this.index.query({
+      vector,
+      topK,
+      includeMetadata: true,
+    });
+    return res.matches ?? [];
+  }
+}


### PR DESCRIPTION
## Summary
- add `openai` and `@pinecone-database/pinecone` dependencies
- implement in-memory and Pinecone vector stores
- add OpenAI summarization utility
- create several agents and a FitnessOrchestrator for routing messages
- export orchestrator helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849970427ec83318b4eee05a51365e2