### PR TITLE
Introduce ChatContext for per-user conversations

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { messages } from '../data/messages';
 import { ChatWindow } from '../plugins/Chat';
+import { ChatProvider } from '../contexts/ChatContext';
 import { Header } from './layout/Header';
 import { TabNavigation } from './pages/TabNavigation';
 import { Overview } from './pages/Overview';
@@ -16,27 +16,10 @@ import { getOverviewById } from '../data/overview';
 function App() {
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState("overview");
-  const [chatMessages, setChatMessages] = useState(messages);
   const [engagementRate, setEngagementRate] = useState(0);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [showChat, setShowChat] = useState(true);
   const [showLeftPanel, setShowLeftPanel] = useState(false);
-
-  const handleSendMessage = (message: string) => {
-    const newMessage = {
-      time: new Date().toLocaleString('en-US', {
-        weekday: 'short',
-        month: 'short',
-        day: '2-digit',
-        year: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: true,
-      }),
-      text: message,
-    };
-    setChatMessages([...chatMessages, newMessage]);
-  };
 
   const handleEngagementRateChange = (rate: number) => {
     setEngagementRate(rate);
@@ -65,31 +48,27 @@ function App() {
     return 'scale-98 opacity-0';
   };
 
-  if (!selectedUserId) {
-    return (
-      <div 
-        className={`h-screen bg-gray-900 font-sans transition-all duration-200 ease-out transform-gpu ${getTransitionClasses()}`}
-      >
-        <div className="bg-gray-800 border-b border-gray-700 px-4 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="w-10 h-10 bg-purple-600 rounded-full flex items-center justify-center">
-                <Dumbbell className="w-6 h-6 text-white" />
-              </div>
-              <span className="text-xl font-bold text-gray-200">Raeda-AI</span>
+  const content = !selectedUserId ? (
+    <div
+      className={`h-screen bg-gray-900 font-sans transition-all duration-200 ease-out transform-gpu ${getTransitionClasses()}`}
+    >
+      <div className="bg-gray-800 border-b border-gray-700 px-4 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-purple-600 rounded-full flex items-center justify-center">
+              <Dumbbell className="w-6 h-6 text-white" />
             </div>
-            <h1 className="text-xl font-bold text-gray-200">Users Overview</h1>
+            <span className="text-xl font-bold text-gray-200">Raeda-AI</span>
           </div>
-        </div>
-        <div className="p-6">
-          <UsersOverview onUserSelect={handleUserSelect} />
+          <h1 className="text-xl font-bold text-gray-200">Users Overview</h1>
         </div>
       </div>
-    );
-  }
-
-  return (
-    <div 
+      <div className="p-6">
+        <UsersOverview onUserSelect={handleUserSelect} />
+      </div>
+    </div>
+  ) : (
+    <div
       className={`h-screen bg-gray-900 font-sans transition-all duration-200 ease-out transform-gpu ${getTransitionClasses()}`}
     >
       {/* Mobile Toggle Navigation */}
@@ -154,9 +133,8 @@ function App() {
               </div>
             </div>
             <Header userId={selectedUserId} />
-            <ChatWindow 
-              messages={chatMessages} 
-              onSendMessage={handleSendMessage}
+            <ChatWindow
+              userId={selectedUserId}
               onEngagementRateChange={handleEngagementRateChange}
             />
           </div>
@@ -198,9 +176,8 @@ function App() {
         {/* Mobile Chat Panel */}
         <div className={`h-full ${!showChat ? 'hidden' : ''}`}>
           <Header userId={selectedUserId} />
-          <ChatWindow 
-            messages={chatMessages} 
-            onSendMessage={handleSendMessage}
+          <ChatWindow
+            userId={selectedUserId}
             onEngagementRateChange={handleEngagementRateChange}
           />
         </div>
@@ -233,6 +210,8 @@ function App() {
       </div>
     </div>
   );
+
+  return <ChatProvider>{content}</ChatProvider>;
 }
 
 export default App;

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -1,0 +1,61 @@
+import React, { createContext, useContext, useState } from 'react';
+import { Message } from '../types/chat';
+import { messages as defaultMessages } from '../data/messages';
+
+interface ChatContextType {
+  conversations: Record<string, Message[]>;
+  sendMessage: (userId: string, text: string) => void;
+  receiveReply: (userId: string, text: string) => void;
+  getHistory: (userId: string) => Message[];
+}
+
+const ChatContext = createContext<ChatContextType | undefined>(undefined);
+
+export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [conversations, setConversations] = useState<Record<string, Message[]>>({
+    '1': defaultMessages
+  });
+
+  const appendMessage = (userId: string, text: string) => {
+    const message: Message = {
+      time: new Date().toLocaleString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: true
+      }),
+      text
+    };
+    setConversations(prev => ({
+      ...prev,
+      [userId]: [...(prev[userId] || []), message]
+    }));
+  };
+
+  const sendMessage = (userId: string, text: string) => {
+    appendMessage(userId, text);
+  };
+
+  const receiveReply = (userId: string, text: string) => {
+    appendMessage(userId, text);
+  };
+
+  const getHistory = (userId: string): Message[] => conversations[userId] || [];
+
+  return (
+    <ChatContext.Provider value={{ conversations, sendMessage, receiveReply, getHistory }}>
+      {children}
+    </ChatContext.Provider>
+  );
+};
+
+export const useChat = () => {
+  const context = useContext(ChatContext);
+  if (!context) {
+    throw new Error('useChat must be used within a ChatProvider');
+  }
+  return context;
+};

--- a/src/plugins/Chat/components/ChatWindow.tsx
+++ b/src/plugins/Chat/components/ChatWindow.tsx
@@ -2,19 +2,20 @@ import React, { useEffect } from 'react';
 import { Message as MessageComponent } from './Message';
 import { ChatInput } from './ChatInput';
 import { calculateEngagementRate } from '../../../utils/engagementUtils';
-import { Message } from '../../../types/chat';
+import { useChat } from '../../../contexts/ChatContext';
 
 interface ChatWindowProps {
-  messages: Message[];
-  onSendMessage: (message: string) => void;
+  userId: string;
   onEngagementRateChange?: (rate: number) => void;
 }
 
-export const ChatWindow: React.FC<ChatWindowProps> = ({ 
-  messages, 
-  onSendMessage,
-  onEngagementRateChange 
+export const ChatWindow: React.FC<ChatWindowProps> = ({
+  userId,
+  onEngagementRateChange
 }) => {
+  const { sendMessage, getHistory } = useChat();
+  const messages = getHistory(userId);
+
   useEffect(() => {
     const engagementRate = calculateEngagementRate(messages);
     onEngagementRateChange?.(engagementRate);
@@ -32,7 +33,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
           />
         ))}
       </div>
-      <ChatInput onSendMessage={onSendMessage} />
+      <ChatInput onSendMessage={(text) => sendMessage(userId, text)} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- implement `ChatContext` to keep chat history keyed by user
- update `ChatWindow` to pull messages from context
- wrap trainer app in `ChatProvider` and pass userId to `ChatWindow`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6849993e7a1c8331b4143a41dd381c06