### PR TITLE
Add global state helper

### DIFF
--- a/src/utils/globalState.ts
+++ b/src/utils/globalState.ts
@@ -1,0 +1,37 @@
+import { getOverviewById } from '../data/overview';
+import { mealPlan } from '../data/mealPlan';
+import { trainingPlan } from '../data/trainingPlan';
+import { events } from '../data/events';
+import { workoutLogs } from '../data/workoutLogs';
+import { messages } from '../data/messages';
+
+export interface GlobalState {
+  overview: ReturnType<typeof getOverviewById> | null;
+  mealPlan: typeof mealPlan | null;
+  trainingPlan: typeof trainingPlan | null;
+  events: typeof events | null;
+  workoutLogs: typeof workoutLogs | null;
+  messages: typeof messages | null;
+}
+
+export const getGlobalState = (userId: string | null): GlobalState => {
+  if (!userId) {
+    return {
+      overview: null,
+      mealPlan: null,
+      trainingPlan: null,
+      events: null,
+      workoutLogs: null,
+      messages: null
+    };
+  }
+
+  return {
+    overview: getOverviewById(userId),
+    mealPlan,
+    trainingPlan,
+    events,
+    workoutLogs,
+    messages
+  };
+};


### PR DESCRIPTION
## Summary
- add a helper to gather global state slices for a user
- return `null` when no user is selected

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a8b320d688331a7ec2ff9955718f3